### PR TITLE
fix case where file has no extension

### DIFF
--- a/gh-release.go
+++ b/gh-release.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"mime"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -62,7 +63,7 @@ func ReleaseIdFromTagname(args []string) {
 
 func MimeType(args []string) {
 	filename := args[0]
-	ext := filename[strings.LastIndex(filename, "."):]
+	ext := filepath.Ext(filename)
 	mime.AddExtensionType(".gz", "application/gzip")
 	mime.AddExtensionType(".tgz", "application/gzip")
 	mime.AddExtensionType(".tar", "application/tar")


### PR DESCRIPTION
Fix issue where adding files to the release with no extension caused:

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
main.MimeType(0x2082d6030, 0x1, 0x1)
        /Users/jrubin/working/go/src/github.com/joshuarubin/gh-release/gh-release.go:65 +0x367
github.com/progrium/go-basher.(*Context).HandleFuncs(0x208360000, 0x2082d6000, 0x4, 0x4, 0x0)
        /Users/jrubin/.gvm/pkgsets/go1.4.2/global/src/github.com/progrium/go-basher/basher.go:181 +0x2e5
github.com/progrium/go-basher.Application(0x208314450, 0x208352f68, 0x1, 0x1, 0x19b380, 0x1)
        /Users/jrubin/.gvm/pkgsets/go1.4.2/global/src/github.com/progrium/go-basher/basher.go:63 +0x5ea
main.main()
        /Users/jrubin/working/go/src/github.com/joshuarubin/gh-release/gh-release.go:109 +0x21c
```