### PR TITLE
destroy: use 'v' prefix only for numbered tags starting with a number

### DIFF
--- a/bash/gh-release.bash
+++ b/bash/gh-release.bash
@@ -20,11 +20,14 @@ release-create() {
 release-destroy() {
 	declare reponame="$1" version="$2"
 	local release_url="$(printf "$release_endpoint" "$reponame")"
-	release_id="$(curl -s "$release_url" | release-id-from-tagname "v$version")"
+    
+    [[ "$version" == [0-9]* ]] && version="v$version"
+
+	release_id="$(curl -s "$release_url?access_token=$GITHUB_ACCESS_TOKEN" | release-id-from-tagname "$version")"
 	echo "Deleting release..."
 	curl -s -X DELETE "$release_url/$release_id?access_token=$GITHUB_ACCESS_TOKEN"
 	echo "Deleting tag..."
-	tag_url="$(printf "$ref_endpoint" "$reponame" "v$version")"
+	tag_url="$(printf "$ref_endpoint" "$reponame" "$version")"
 	curl -s -X DELETE "$tag_url?access_token=$GITHUB_ACCESS_TOKEN"
 }
 


### PR DESCRIPTION
With this change `gh-release` can destroy any release, even those which aren't follow the usual naming convention: **vX.Y.Z**