### PR TITLE
Fixing Upload URL Parsing

### DIFF
--- a/gh-release.go
+++ b/gh-release.go
@@ -49,7 +49,7 @@ func UploadUrl(args []string) {
 	if i > -1 {
 		url = url[:i]
 	}
-	fmt.Println(url + "?name=")
+	fmt.Println(url + "?name")
 }
 
 func ReleaseIdFromTagname(args []string) {


### PR DESCRIPTION
Prior to this patch, the interpolated upload url ends up with two
equal signs (?name==asset-name) and uploads fail.